### PR TITLE
Fix status value when using Baserow select fields

### DIFF
--- a/src/components/AddItemForm.tsx
+++ b/src/components/AddItemForm.tsx
@@ -33,7 +33,11 @@ export default function AddItemForm({
       setName(initialData.Name || '');
       setGame(initialData.Game || '');
       setFaction(initialData.Faction || '');
-      setStatus(initialData.Status || STATUS_OPTIONS[0]);
+      const statusValue =
+        initialData.Status && typeof initialData.Status === 'object'
+          ? initialData.Status.value
+          : initialData.Status;
+      setStatus(statusValue || STATUS_OPTIONS[0]);
       setQuantity(initialData.Quantity || 1);
       setNotes(initialData.Notes || '');
     }

--- a/src/components/CollectionItemCard.tsx
+++ b/src/components/CollectionItemCard.tsx
@@ -5,9 +5,11 @@ import Modal from './Modal';
 import AddItemForm from './AddItemForm';
 
 function DetailRow({ label, value }: { label: string; value: any }) {
+  const displayValue =
+    value && typeof value === 'object' ? value.value ?? '—' : value;
   return (
     <div className="text-sm text-gray-700">
-      <span className="font-medium">{label}:</span> {value || '—'}
+      <span className="font-medium">{label}:</span> {displayValue || '—'}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- handle Baserow single select objects in `DetailRow`
- normalize status value in `AddItemForm` when editing an item

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f3e18f7ec8322932eb36f54dfdfbc