### PR TITLE
Fix editing to update existing records

### DIFF
--- a/src/components/AddItemForm.tsx
+++ b/src/components/AddItemForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { addCollectionItem } from '../lib/api';
+import { addCollectionItem, updateCollectionItem } from '../lib/api';
 
 const STATUS_OPTIONS = [
   'New in Box',
@@ -33,7 +33,11 @@ export default function AddItemForm({
       setName(initialData.Name || '');
       setGame(initialData.Game || '');
       setFaction(initialData.Faction || '');
-      setStatus(initialData.Status || STATUS_OPTIONS[0]);
+      const statusValue =
+        initialData.Status && typeof initialData.Status === 'object'
+          ? initialData.Status.value
+          : initialData.Status;
+      setStatus(statusValue || STATUS_OPTIONS[0]);
       setQuantity(initialData.Quantity || 1);
       setNotes(initialData.Notes || '');
     }
@@ -43,14 +47,25 @@ export default function AddItemForm({
     e.preventDefault();
     if (!name || !game) return;
 
-    await addCollectionItem({
-      Name: name,
-      Game: game,
-      Faction: faction,
-      Status: status,
-      Quantity: quantity,
-      Notes: notes,
-    });
+    if (initialData && initialData.id) {
+      await updateCollectionItem(initialData.id, {
+        Name: name,
+        Game: game,
+        Faction: faction,
+        Status: status,
+        Quantity: quantity,
+        Notes: notes,
+      });
+    } else {
+      await addCollectionItem({
+        Name: name,
+        Game: game,
+        Faction: faction,
+        Status: status,
+        Quantity: quantity,
+        Notes: notes,
+      });
+    }
 
     // Reset only if we're adding
     if (!initialData) {

--- a/src/components/CollectionItemCard.tsx
+++ b/src/components/CollectionItemCard.tsx
@@ -5,9 +5,11 @@ import Modal from './Modal';
 import AddItemForm from './AddItemForm';
 
 function DetailRow({ label, value }: { label: string; value: any }) {
+  const displayValue =
+    value && typeof value === 'object' ? value.value ?? '—' : value;
   return (
     <div className="text-sm text-gray-700">
-      <span className="font-medium">{label}:</span> {value || '—'}
+      <span className="font-medium">{label}:</span> {displayValue || '—'}
     </div>
   );
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -33,3 +33,23 @@ export async function addCollectionItem(item: Record<string, any>) {
     throw error;
   }
 }
+
+// Update an existing collection item
+export async function updateCollectionItem(
+  id: number | string,
+  item: Record<string, any>
+) {
+  try {
+    const [base, query] = BASE_URL.split('?');
+    const url = `${base}${id}/${query ? `?${query}` : ''}`;
+    const res = await axios.patch(url, item, {
+      headers: {
+        Authorization: `Token ${API_TOKEN}`
+      }
+    });
+    return res.data;
+  } catch (error) {
+    console.error('Error updating collection item:', error);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- support updating rows in Baserow via a new API helper
- call the update API when saving changes from the item edit modal

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f3e18f7ec8322932eb36f54dfdfbc