### PR TITLE
Fix summary counting logic

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,8 +38,14 @@ export default function Dashboard() {
 
   // Summary info
   const totalEntries = collection.length;
-  const totalModels = collection.reduce((sum, item) => sum + (item.Quantity || 0), 0);
-  const completed = collection.reduce((sum, item) => sum + (item.Completed || 0), 0);
+  const totalModels = collection.reduce(
+    (sum, item) => sum + (parseInt(item.Quantity as string, 10) || 0),
+    0,
+  );
+  const completed = collection.reduce(
+    (sum, item) => sum + (parseInt(item.Completed as string, 10) || 0),
+    0,
+  );
 
   return (
     <DashboardShell>


### PR DESCRIPTION
## Summary
- fix numeric parsing in the dashboard summary so string quantities sum correctly

## Testing
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683f45bf474c8322834cfa8350dda04e